### PR TITLE
Fix postinstall build when used as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@capacitor/core": "3.4.0",
-                "typescript": "4.1.5"
+                "typescript": "4.3.5"
             },
             "devDependencies": {
                 "@capacitor/android": "3.0.2",
@@ -21,6 +20,9 @@
                 "jest": "27.0.6",
                 "rimraf": "3.0.2",
                 "ts-jest": "27.0.4"
+            },
+            "peerDependencies": {
+                "@capacitor/core": "^3.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -679,9 +681,10 @@
             }
         },
         "node_modules/@capacitor/core": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.4.0.tgz",
-            "integrity": "sha512-utfMAYZyU8SL+JkVOcqanjmWarSBlvCyVDPL6AnXG/B//9VtleZ5NtorUXL0ggnK7t+Zbd8xGgA+LN7mn4+3Lw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.2.tgz",
+            "integrity": "sha512-uvKvX++uj17pK2LYekPJlxsEprUTmqPk/SdDwczj5I/pmloAV8TkQ/zqwI+yOC9h6hEwRBZ689TGTS1GfPnYuA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -1464,9 +1467,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -4799,9 +4802,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "node_modules/mkdirp": {
@@ -5533,9 +5536,9 @@
             "dev": true
         },
         "node_modules/tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
         "node_modules/to-fast-properties": {
@@ -5630,7 +5633,8 @@
         "node_modules/tslib": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -5675,9 +5679,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-            "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6440,9 +6444,10 @@
             "requires": {}
         },
         "@capacitor/core": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.4.0.tgz",
-            "integrity": "sha512-utfMAYZyU8SL+JkVOcqanjmWarSBlvCyVDPL6AnXG/B//9VtleZ5NtorUXL0ggnK7t+Zbd8xGgA+LN7mn4+3Lw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.2.tgz",
+            "integrity": "sha512-uvKvX++uj17pK2LYekPJlxsEprUTmqPk/SdDwczj5I/pmloAV8TkQ/zqwI+yOC9h6hEwRBZ689TGTS1GfPnYuA==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.1.0"
             }
@@ -7119,9 +7124,9 @@
             }
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
         "ansi-styles": {
@@ -9760,9 +9765,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "mkdirp": {
@@ -10313,9 +10318,9 @@
             "dev": true
         },
         "tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
         "to-fast-properties": {
@@ -10374,7 +10379,8 @@
         "tslib": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+            "peer": true
         },
         "type-check": {
             "version": "0.4.0",
@@ -10407,9 +10413,9 @@
             }
         },
         "typescript": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-            "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
         },
         "universalify": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,6 @@
         "prepublishOnly": "npm run build",
         "postinstall": "npm run build"
     },
-    "files": [
-        "android/src/main/",
-        "android/build.gradle",
-        "dist/",
-        "ios/ByteowlsCapacitorOauth2/Source",
-        "ByteowlsCapacitorOauth2.podspec"
-    ],
     "keywords": [
         "capacitor",
         "capacitor-plugin",
@@ -50,9 +43,11 @@
     "publishConfig": {
         "access": "public"
     },
+    "peerDependencies": {
+        "@capacitor/core": "^3.0.0"
+    },
     "dependencies": {
-        "typescript": "4.1.5",
-        "@capacitor/core": "3.4.0"
+        "typescript": "4.3.5"
     },
     "devDependencies": {
         "@capacitor/android": "3.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,12 @@
         "allowUnreachableCode": false,
         "declaration": true,
         "esModuleInterop": true,
-        "lib": ["dom", "es2017"],
+        "skipLibCheck": true,
+        "lib": [
+            "ES2020",
+            "DOM",
+            "DOM.Iterable",
+        ],
         "module": "esnext",
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
@@ -16,5 +21,7 @@
         "strictPropertyInitialization": false,
         "target": "es2017"
     },
-    "files": ["src/index.ts"]
+    "files": [
+        "src/index.ts"
+    ]
 }


### PR DESCRIPTION
Changes that fixed build issues:
- remove `files` entry from package.json
- add `skipLibCheck` to tsconfig

other changes:
- update TS to `4.3.5`
- `npm audit fix` to bump some vulnerable dependencies
- other minor tsconfig changes